### PR TITLE
gapplication: use Gtk.Application

### DIFF
--- a/bin/meson.build
+++ b/bin/meson.build
@@ -1,5 +1,4 @@
 bin_conf = configuration_data()
-bin_conf.set('appdir', join_paths(prefix, appdir))
 bin_conf.set('pkgdatadir', join_paths(prefix, pkgdatadir))
 
 configure_file(

--- a/bin/pulseaudio-equalizer-gtk.in
+++ b/bin/pulseaudio-equalizer-gtk.in
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env python
 
-# PulseAudio LADSPA Equalizer - wrapper script
-# Author: Conn O'Griofa <connogriofa AT gmail DOT com>
-# Version: (see '/usr/pulseaudio-equalizer' script)
+from pulseeq import equalizer
 
-/usr/bin/env python @appdir@/equalizer.py
+import sys
+
+app = equalizer.Application()
+app.run(sys.argv)
+


### PR DESCRIPTION
Make Equalizer class inherit Gtk.ApplicationWindow and use
Gtk.Application instead of just a gtk mainloop.

Change the python wrapper startscript to a python script that imports
the application and starts it.