### PR TITLE
redesign: use gtkbuilder ui file

### DIFF
--- a/bin/meson.build
+++ b/bin/meson.build
@@ -1,4 +1,5 @@
 bin_conf = configuration_data()
+bin_conf.set('appid', appid)
 bin_conf.set('pkgdatadir', join_paths(prefix, pkgdatadir))
 
 configure_file(

--- a/bin/pulseaudio-equalizer-gtk.in
+++ b/bin/pulseaudio-equalizer-gtk.in
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 
-from pulseeq import equalizer
+import sys, os
+from gi.repository import Gio
 
-import sys
+resource = Gio.resource_load(
+    os.path.join('@pkgdatadir@', '@appid@.gresource'))
+Gio.Resource._register(resource)
+
+from pulseeq import equalizer
 
 app = equalizer.Application()
 app.run(sys.argv)
-

--- a/data/com.github.pulseaudio-equalizer-ladspa.Equalizer.gresource.xml
+++ b/data/com.github.pulseaudio-equalizer-ladspa.Equalizer.gresource.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/github/pulseaudio-equalizer-ladspa/Equalizer">
+    <file preprocess="xml-stripblanks">ui/Equalizer.ui</file>
+  </gresource>
+</gresources>
+

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,5 +1,17 @@
 install_subdir('presets', install_dir: pkgdatadir)
 
-install_data('com.github.pulseaudio-equalizer-ladspa.Equalizer.desktop',
+install_data(appid + '.desktop',
     install_dir: join_paths(datadir, 'applications'),
+)
+
+gnome = import('gnome')
+
+# Compiling the resources
+gnome.compile_resources(
+  appid,
+  appid + '.gresource.xml',
+  gresource_bundle: true,
+  source_dir: meson.current_build_dir(),
+  install_dir: pkgdatadir,
+  install: true
 )

--- a/data/ui/Equalizer.ui
+++ b/data/ui/Equalizer.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="Equalizer" parent="GtkApplicationWindow">
+    <property name="title">PulseAudio Equalizer</property>
+    <property name="icon-name">multimedia-volume-control</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkMenuBar">
+            <property name="visible">True</property>
+            <child>
+              <object class="GtkMenuItem">
+                <property name="visible">True</property>
+                <property name="label">Advanced</property>
+                <child type="submenu">
+                  <object class="GtkMenu">
+                    <property name="visible">True</property>
+                    <child>
+                      <object class="GtkMenuItem">
+                        <property name="visible">True</property>
+                        <property name="label">Reset to defaults</property>
+                        <signal name="activate" handler="on_resetsettings"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem">
+                        <property name="visible">True</property>
+                        <property name="label">Remove user preset...</property>
+                        <signal name="activate" handler="on_removepreset"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="orientation">horizontal</property>
+            <property name="spacing">1</property>
+            <property name="vexpand">True</property>
+            <child>
+              <object class="GtkTable" id="table">
+                <property name="visible">True</property>
+                <property name="n_rows">3</property>
+                <property name="n_columns">17</property>
+                <property name="hexpand">True</property>
+                <property name="border_width">5</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="orientation">vertical</property>
+                <property name="homogeneous">True</property>
+                <property name="spacing">1</property>
+                <property name="hexpand">True</property>
+                <property name="border_width">10</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="use-markup">True</property>
+                    <property name="valign">center</property>
+                    <property name="label">&lt;small&gt;Preset:&lt;/small&gt;</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkComboBoxText" id="presetsbox">
+                    <property name="visible">True</property>
+                    <property name="has_entry">True</property>
+                    <property name="valign">center</property>
+                    <child internal-child="entry">
+                      <object class="GtkEntry">
+                      </object>
+                    </child>
+                    <signal name="changed" handler="on_presetsbox" swapped="no"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton">
+                    <property name="visible">True</property>
+                    <property name="label">Save Preset</property>
+                    <property name="valign">center</property>
+                    <signal name="clicked" handler="on_savepreset" swapped="no"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="eqenabled">
+                    <property name="visible">True</property>
+                    <property name="label">EQ Enabled</property>
+                    <property name="valign">center</property>
+                    <signal name="clicked" handler="on_eqenabled" swapped="no"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="keepsettings">
+                    <property name="visible">True</property>
+                    <property name="label">Keep Settings</property>
+                    <property name="valign">center</property>
+                    <signal name="clicked" handler="on_keepsettings" swapped="no"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton" id="applysettings">
+                    <property name="visible">True</property>
+                    <property name="label">Apply Settings</property>
+                    <property name="valign">center</property>
+                    <signal name="clicked" handler="on_applysettings" swapped="no"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton">
+                    <property name="visible">True</property>
+                    <property name="label">Quit</property>
+                    <property name="valign">center</property>
+                    <signal name="clicked" handler="on_quit" swapped="no"/>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>
+

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ pymod = import('python')
 python = pymod.find_installation()
 
 modname = 'pulseeq'
+appid = 'com.github.pulseaudio-equalizer-ladspa.Equalizer'
 
 prefix = get_option('prefix')
 bindir = get_option('bindir')


### PR DESCRIPTION
Add ui template file for the Equalizer ApplicationWindow and make use of
it trough @Gtk.Template.

The ui file is compiled into a GResource which needs to be sourced
before the Equalizer class file gets imported.

Most of the not dynamically created widgets have beend moved from the
python source to the template. Buttons signals are also mapped in the ui
file. The corresponding callback functions are marked with
@Gtk.Template.Callback().