### PR TITLE
Redesign

### DIFF
--- a/data/com.github.pulseaudio-equalizer-ladspa.Equalizer.gresource.xml
+++ b/data/com.github.pulseaudio-equalizer-ladspa.Equalizer.gresource.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
   <gresource prefix="/com/github/pulseaudio-equalizer-ladspa/Equalizer">
+    <file alias="gtk/menus.ui" preprocess="xml-stripblanks">ui/app-menu.ui</file>
     <file preprocess="xml-stripblanks">ui/Equalizer.ui</file>
   </gresource>
 </gresources>

--- a/data/ui/Equalizer.ui
+++ b/data/ui/Equalizer.ui
@@ -8,6 +8,24 @@
         <property name="visible">True</property>
         <property name="show_close_button">True</property>
         <property name="title">PulseAudio Equalizer</property>
+        <child>
+          <object class="GtkButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="action_name">win.save</property>
+            <property name="tooltip-text">Save current preset</property>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="icon-name">document-save-symbolic</property>
+              </object>
+            </child>
+          </object>
+        </child>
         <child type="title">
           <object class="GtkComboBoxText" id="presetsbox">
             <property name="visible">True</property>
@@ -59,14 +77,6 @@
                 <property name="spacing">1</property>
                 <property name="hexpand">True</property>
                 <property name="border_width">10</property>
-                <child>
-                  <object class="GtkButton">
-                    <property name="visible">True</property>
-                    <property name="label">Save Preset</property>
-                    <property name="valign">center</property>
-                    <signal name="clicked" handler="on_savepreset" swapped="no"/>
-                  </object>
-                </child>
                 <child>
                   <object class="GtkButton" id="applysettings">
                     <property name="visible">True</property>

--- a/data/ui/Equalizer.ui
+++ b/data/ui/Equalizer.ui
@@ -26,6 +26,23 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="GtkButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="action_name">win.remove</property>
+            <property name="tooltip-text">Remove current preset</property>
+            <style>
+              <class name="destructive-action"/>
+            </style>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="icon-name">user-trash-symbolic</property>
+              </object>
+            </child>
+          </object>
+        </child>
         <child type="title">
           <object class="GtkComboBoxText" id="presetsbox">
             <property name="visible">True</property>

--- a/data/ui/Equalizer.ui
+++ b/data/ui/Equalizer.ui
@@ -68,44 +68,11 @@
       </object>
     </child>
     <child>
-      <object class="GtkBox">
+      <object class="GtkTable" id="table">
         <property name="visible">True</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="orientation">horizontal</property>
-            <property name="spacing">1</property>
-            <property name="vexpand">True</property>
-            <child>
-              <object class="GtkTable" id="table">
-                <property name="visible">True</property>
-                <property name="n_rows">3</property>
-                <property name="n_columns">17</property>
-                <property name="hexpand">True</property>
-                <property name="border_width">5</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="visible">True</property>
-                <property name="orientation">vertical</property>
-                <property name="homogeneous">True</property>
-                <property name="spacing">1</property>
-                <property name="hexpand">True</property>
-                <property name="border_width">10</property>
-                <child>
-                  <object class="GtkButton">
-                    <property name="visible">True</property>
-                    <property name="label">Quit</property>
-                    <property name="valign">center</property>
-                    <signal name="clicked" handler="on_quit" swapped="no"/>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
+        <property name="n_rows">3</property>
+        <property name="n_columns">17</property>
+        <property name="border_width">5</property>
       </object>
     </child>
   </template>

--- a/data/ui/Equalizer.ui
+++ b/data/ui/Equalizer.ui
@@ -9,36 +9,6 @@
         <property name="visible">True</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkMenuBar">
-            <property name="visible">True</property>
-            <child>
-              <object class="GtkMenuItem">
-                <property name="visible">True</property>
-                <property name="label">Advanced</property>
-                <child type="submenu">
-                  <object class="GtkMenu">
-                    <property name="visible">True</property>
-                    <child>
-                      <object class="GtkMenuItem">
-                        <property name="visible">True</property>
-                        <property name="label">Reset to defaults</property>
-                        <signal name="activate" handler="on_resetsettings"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem">
-                        <property name="visible">True</property>
-                        <property name="label">Remove user preset...</property>
-                        <signal name="activate" handler="on_removepreset"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="orientation">horizontal</property>

--- a/data/ui/Equalizer.ui
+++ b/data/ui/Equalizer.ui
@@ -68,11 +68,11 @@
       </object>
     </child>
     <child>
-      <object class="GtkTable" id="table">
+      <object class="GtkGrid" id="grid">
         <property name="visible">True</property>
-        <property name="n_rows">3</property>
-        <property name="n_columns">17</property>
-        <property name="border_width">5</property>
+        <property name="margin">5</property>
+        <property name="margin_top">10</property>
+        <property name="margin_bottom">10</property>
       </object>
     </child>
   </template>

--- a/data/ui/Equalizer.ui
+++ b/data/ui/Equalizer.ui
@@ -4,6 +4,12 @@
   <template class="Equalizer" parent="GtkApplicationWindow">
     <property name="title">PulseAudio Equalizer</property>
     <property name="icon-name">multimedia-volume-control</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="headerbar">
+        <property name="visible">True</property>
+        <property name="show_close_button">True</property>
+      </object>
+    </child>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>

--- a/data/ui/Equalizer.ui
+++ b/data/ui/Equalizer.ui
@@ -95,14 +95,6 @@
                 <property name="hexpand">True</property>
                 <property name="border_width">10</property>
                 <child>
-                  <object class="GtkButton" id="applysettings">
-                    <property name="visible">True</property>
-                    <property name="label">Apply Settings</property>
-                    <property name="valign">center</property>
-                    <signal name="clicked" handler="on_applysettings" swapped="no"/>
-                  </object>
-                </child>
-                <child>
                   <object class="GtkButton">
                     <property name="visible">True</property>
                     <property name="label">Quit</property>

--- a/data/ui/Equalizer.ui
+++ b/data/ui/Equalizer.ui
@@ -2,12 +2,22 @@
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <template class="Equalizer" parent="GtkApplicationWindow">
-    <property name="title">PulseAudio Equalizer</property>
     <property name="icon-name">multimedia-volume-control</property>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="headerbar">
         <property name="visible">True</property>
         <property name="show_close_button">True</property>
+        <property name="title">PulseAudio Equalizer</property>
+        <child>
+          <object class="GtkSwitch">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="action_name">win.eqenabled</property>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+          </packing>
+        </child>
       </object>
     </child>
     <child>
@@ -63,22 +73,6 @@
                     <property name="label">Save Preset</property>
                     <property name="valign">center</property>
                     <signal name="clicked" handler="on_savepreset" swapped="no"/>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="eqenabled">
-                    <property name="visible">True</property>
-                    <property name="label">EQ Enabled</property>
-                    <property name="valign">center</property>
-                    <signal name="clicked" handler="on_eqenabled" swapped="no"/>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="keepsettings">
-                    <property name="visible">True</property>
-                    <property name="label">Keep Settings</property>
-                    <property name="valign">center</property>
-                    <signal name="clicked" handler="on_keepsettings" swapped="no"/>
                   </object>
                 </child>
                 <child>

--- a/data/ui/Equalizer.ui
+++ b/data/ui/Equalizer.ui
@@ -8,6 +8,18 @@
         <property name="visible">True</property>
         <property name="show_close_button">True</property>
         <property name="title">PulseAudio Equalizer</property>
+        <child type="title">
+          <object class="GtkComboBoxText" id="presetsbox">
+            <property name="visible">True</property>
+            <property name="has_entry">True</property>
+            <property name="valign">center</property>
+            <child internal-child="entry">
+              <object class="GtkEntry">
+              </object>
+            </child>
+            <signal name="changed" handler="on_presetsbox" swapped="no"/>
+          </object>
+        </child>
         <child>
           <object class="GtkSwitch">
             <property name="visible">True</property>
@@ -47,26 +59,6 @@
                 <property name="spacing">1</property>
                 <property name="hexpand">True</property>
                 <property name="border_width">10</property>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="use-markup">True</property>
-                    <property name="valign">center</property>
-                    <property name="label">&lt;small&gt;Preset:&lt;/small&gt;</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkComboBoxText" id="presetsbox">
-                    <property name="visible">True</property>
-                    <property name="has_entry">True</property>
-                    <property name="valign">center</property>
-                    <child internal-child="entry">
-                      <object class="GtkEntry">
-                      </object>
-                    </child>
-                    <signal name="changed" handler="on_presetsbox" swapped="no"/>
-                  </object>
-                </child>
                 <child>
                   <object class="GtkButton">
                     <property name="visible">True</property>

--- a/data/ui/app-menu.ui
+++ b/data/ui/app-menu.ui
@@ -7,10 +7,6 @@
         <attribute name="action">app.resetsettings</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">Remove user preset…</attribute>
-        <attribute name="action">app.removepreset</attribute>
-      </item>
-      <item>
         <attribute name="label" translatable="yes">Keep Settings</attribute>
         <attribute name="action">app.keepsettings</attribute>
       </item>

--- a/data/ui/app-menu.ui
+++ b/data/ui/app-menu.ui
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <menu id="app-menu">
+    <section>
+      <item>
+        <attribute name="label" translatable="yes">Reset to defaults</attribute>
+        <attribute name="action">app.resetsettings</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Remove user preset…</attribute>
+        <attribute name="action">app.removepreset</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">_Quit</attribute>
+        <attribute name="action">app.quit</attribute>
+        <attribute name="accel">&lt;Primary&gt;q</attribute>
+      </item>
+    </section>
+  </menu>
+</interface>
+

--- a/data/ui/app-menu.ui
+++ b/data/ui/app-menu.ui
@@ -11,6 +11,10 @@
         <attribute name="action">app.removepreset</attribute>
       </item>
       <item>
+        <attribute name="label" translatable="yes">Keep Settings</attribute>
+        <attribute name="action">app.keepsettings</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">_Quit</attribute>
         <attribute name="action">app.quit</attribute>
         <attribute name="accel">&lt;Primary&gt;q</attribute>

--- a/pulseeq/equalizer.py
+++ b/pulseeq/equalizer.py
@@ -324,10 +324,6 @@ class Equalizer(Gtk.ApplicationWindow):
 
         action.set_enabled(False)
 
-    @Gtk.Template.Callback()
-    def on_quit(self, object=None, param=None):
-        Gio.Application.get_default().quit()
-
     def __init__(self, *args, **kwargs):
         super(Equalizer, self).__init__(*args, **kwargs)
         GetSettings()
@@ -387,9 +383,9 @@ class Equalizer(Gtk.ApplicationWindow):
             scalevalue = Gtk.Label()
             self.scalevalues[x] = scalevalue
             scalevalue.set_markup('<small>' + str(scale.get_value())  + '\ndB</small>')
-            self.table.attach(label, x + 2, x + 3, 0, 1)
+            self.table.attach(label, x + 2, x + 3, 0, 1, Gtk.AttachOptions.SHRINK, Gtk.AttachOptions.SHRINK)
             self.table.attach(scale, x + 2, x + 3, 1, 2)
-            self.table.attach(scalevalue, x + 2, x + 3, 2, 3)
+            self.table.attach(scalevalue, x + 2, x + 3, 2, 3, Gtk.AttachOptions.SHRINK, Gtk.AttachOptions.SHRINK)
             label.show()
             scale.show()
             scalevalue.show()
@@ -443,7 +439,7 @@ class Application(Gtk.Application):
         self.add_action(action)
 
         action = Gio.SimpleAction.new('quit', None)
-        action.connect('activate', self.window.on_quit)
+        action.connect('activate', self.on_quit)
         self.add_action(action)
 
     def do_activate(self):
@@ -457,3 +453,6 @@ class Application(Gtk.Application):
         persistence = int(state.get_boolean())
         ApplySettings()
         action.set_state(state)
+
+    def on_quit(self, action, param):
+        Gio.Application.get_default().quit()

--- a/pulseeq/equalizer.py
+++ b/pulseeq/equalizer.py
@@ -159,6 +159,16 @@ class Equalizer(Gtk.ApplicationWindow):
         for i in range(1, num_ladspa_controls + 1):
             self.scalevalues[i].set_markup('<small>' + str(float(ladspa_controls[i - 1])) + '\ndB</small>')
 
+        if self.apply_event_source is not None:
+            GLib.source_remove (self.apply_event_source);
+
+        self.apply_event_source = GLib.timeout_add (500, self.on_apply_event)
+
+    def on_apply_event(self):
+        ApplySettings()
+        self.apply_event_source = None
+        return False
+
     @Gtk.Template.Callback()
     def on_presetsbox(self, widget):
         global preset
@@ -222,10 +232,6 @@ class Equalizer(Gtk.ApplicationWindow):
             self.lookup_action('save').set_enabled(False)
         else:
             self.lookup_action('save').set_enabled(preset != '')
-
-    @Gtk.Template.Callback()
-    def on_applysettings(self, widget):
-        ApplySettings()
 
     def on_resetsettings(self, action=None, param=None):
         print('Resetting to defaults...')
@@ -325,6 +331,8 @@ class Equalizer(Gtk.ApplicationWindow):
     def __init__(self, *args, **kwargs):
         super(Equalizer, self).__init__(*args, **kwargs)
         GetSettings()
+
+        self.apply_event_source = None
 
         # Preamp widget
         global preampscale

--- a/pulseeq/equalizer.py
+++ b/pulseeq/equalizer.py
@@ -216,6 +216,10 @@ class Equalizer(Gtk.ApplicationWindow):
             self.presetsbox.get_child().set_text(preset)
             ApplySettings()
 
+            self.lookup_action('save').set_enabled(False)
+        else:
+            self.lookup_action('save').set_enabled(preset != '')
+
     @Gtk.Template.Callback()
     def on_applysettings(self, widget):
         ApplySettings()
@@ -235,8 +239,7 @@ class Equalizer(Gtk.ApplicationWindow):
             self.labels[i].set_markup('<small>' + whitespace1 + c + '\n' + whitespace2 + suffix + '</small>')
             self.scalevalues[i].set_markup('<small>' + str(float(ladspa_controls[i - 1])) + '\ndB</small>')
 
-    @Gtk.Template.Callback()
-    def on_savepreset(self, widget):
+    def on_savepreset(self, action, param):
         global preset
         global presetmatch
         preset = self.presetsbox.get_child().get_text()
@@ -273,6 +276,8 @@ class Equalizer(Gtk.ApplicationWindow):
             # Repopulate preset list into ComboBox
             for i in range(len(rawpresets)):
                 self.presetsbox.append_text(rawpresets[i])
+
+            action.set_enabled(False)
 
     def on_preampscale(self, widget):
         global preamp
@@ -407,6 +412,11 @@ class Equalizer(Gtk.ApplicationWindow):
             label.show()
             scale.show()
             scalevalue.show()
+
+        action = Gio.SimpleAction.new('save', None)
+        action.set_enabled(False)
+        action.connect('activate', self.on_savepreset)
+        self.add_action(action)
 
         self.presetsbox.get_child().set_text(preset)
         for i in range(len(rawpresets)):

--- a/pulseeq/equalizer.py
+++ b/pulseeq/equalizer.py
@@ -143,7 +143,7 @@ def FormatLabels(x):
 class Equalizer(Gtk.ApplicationWindow):
     __gtype_name__= "Equalizer"
 
-    table = Gtk.Template.Child()
+    grid = Gtk.Template.Child()
     presetsbox = Gtk.Template.Child()
 
     def on_scale(self, widget, y):
@@ -333,30 +333,24 @@ class Equalizer(Gtk.ApplicationWindow):
         # Preamp widget
         global preampscale
         global preampscalevalue
-        preampscale = Gtk.Scale(orientation=Gtk.Orientation.VERTICAL)
-        preampscale.set_draw_value(0)
-        preampscale.set_inverted(1)
+        preampscale = Gtk.Scale(orientation=Gtk.Orientation.VERTICAL,
+                                draw_value=False, inverted=True, digits=1)
         preampscale.set_value_pos(Gtk.PositionType.BOTTOM)
         preampscale.set_range(0.0, 2.0)
         preampscale.set_increments(1, 0.1)
-        preampscale.set_digits(1)
         preampscale.set_size_request(35, 200)
         preampscale.set_value(float(preamp))
         preampscale.connect('value-changed', self.on_preampscale)
-        label = Gtk.Label()
-        label.set_markup('<small>Preamp</small>')
-        preampscalevalue = Gtk.Label()
-        preampscalevalue.set_markup(str(preampscale.get_value()) + 'x')
-        self.table.attach(label, 1, 2, 0, 1)
-        self.table.attach(preampscale, 1, 2, 1, 2)
-        self.table.attach(preampscalevalue, 1, 2, 2, 3)
-        # label.show()
-        # preampscale.show()
-        # preampscalevalue.show()
+        label = Gtk.Label(use_markup=True, label='<small>Preamp</small>')
+        preampscalevalue = Gtk.Label(use_markup=True,
+                                     label=str(preampscale.get_value()) + 'x')
+        self.grid.attach(label, 0, 0, 1, 1)
+        self.grid.attach(preampscale, 0, 1, 1, 2)
+        self.grid.attach(preampscalevalue, 0, 3, 1, 1)
 
         # Separator between preamp and bands
         separator = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
-        self.table.attach(separator, 2, 3, 1, 2)
+        self.grid.attach(separator, 1, 0, 1, 3)
         # separator.show()
 
         # Equalizer bands
@@ -365,30 +359,25 @@ class Equalizer(Gtk.ApplicationWindow):
         self.labels = {}
         self.scalevalues = {}
         for x in range(1, num_ladspa_controls + 1):
-            scale = Gtk.Scale(orientation=Gtk.Orientation.VERTICAL)
+            scale = Gtk.Scale(orientation=Gtk.Orientation.VERTICAL,
+                              draw_value=False, inverted=True, digits=1,
+                              expand=True, visible=True)
             self.scales[x] = scale
-            scale.set_draw_value(0)
-            scale.set_inverted(1)
-            scale.set_value_pos(Gtk.PositionType.BOTTOM)
             scale.set_range(float(ranges[0]), float(ranges[1]))
             scale.set_increments(1, 0.1)
-            scale.set_digits(1)
             scale.set_size_request(35, 200)
             scale.set_value(float(ladspa_controls[x - 1]))
             scale.connect('value-changed', self.on_scale, x)
             FormatLabels(x)
-            label = Gtk.Label()
+            label = Gtk.Label(use_markup=True, visible=True,
+                label = '<small>' + whitespace1 + c + '\n'  + whitespace2 + suffix + '</small>')
             self.labels[x] = label
-            label.set_markup('<small>' + whitespace1 + c + '\n'  + whitespace2 + suffix + '</small>')
-            scalevalue = Gtk.Label()
+            scalevalue = Gtk.Label(visible=True, use_markup=True,
+                label='<small>' + str(scale.get_value())  + '\ndB</small>')
             self.scalevalues[x] = scalevalue
-            scalevalue.set_markup('<small>' + str(scale.get_value())  + '\ndB</small>')
-            self.table.attach(label, x + 2, x + 3, 0, 1, Gtk.AttachOptions.SHRINK, Gtk.AttachOptions.SHRINK)
-            self.table.attach(scale, x + 2, x + 3, 1, 2)
-            self.table.attach(scalevalue, x + 2, x + 3, 2, 3, Gtk.AttachOptions.SHRINK, Gtk.AttachOptions.SHRINK)
-            label.show()
-            scale.show()
-            scalevalue.show()
+            self.grid.attach(label, x + 1, 0, 1, 1)
+            self.grid.attach(scale, x + 1, 1, 1, 2)
+            self.grid.attach(scalevalue, x + 1, 3, 1, 1)
 
         action = Gio.SimpleAction.new('save', None)
         action.set_enabled(False)

--- a/pulseeq/equalizer.py
+++ b/pulseeq/equalizer.py
@@ -234,8 +234,7 @@ class Equalizer(Gtk.ApplicationWindow):
     def on_applysettings(self, widget):
         ApplySettings()
 
-    @Gtk.Template.Callback()
-    def on_resetsettings(self, widget):
+    def on_resetsettings(self, action=None, param=None):
         print('Resetting to defaults...')
         os.system('pulseaudio-equalizer interface.resetsettings')
         GetSettings()
@@ -316,8 +315,7 @@ class Equalizer(Gtk.ApplicationWindow):
             persistence = 0
         ApplySettings()
 
-    @Gtk.Template.Callback()
-    def on_removepreset(self, widget):
+    def on_removepreset(self, action=None, param=None):
         global preset
         global presets
         dialog = Gtk.FileChooserDialog(title='Choose preset to remove...',
@@ -371,7 +369,7 @@ class Equalizer(Gtk.ApplicationWindow):
         dialog.destroy()
 
     @Gtk.Template.Callback()
-    def on_quit(self, widget):
+    def on_quit(self, object=None, param=None):
         Gio.Application.get_default().quit()
 
     def __init__(self, *args, **kwargs):
@@ -456,8 +454,27 @@ class Application(Gtk.Application):
     def __init__(self, *args, **kwargs):
         super(Application, self).__init__(*args,
             application_id='com.github.pulseaudio-equalizer-ladspa.Equalizer',
+            resource_base_path='/com/github/pulseaudio-equalizer-ladspa/Equalizer',
             **kwargs)
+
         self.window = None
+
+    def do_startup(self):
+        Gtk.Application.do_startup(self)
+
+        self.window = Equalizer(application=self)
+
+        action = Gio.SimpleAction.new('resetsettings', None)
+        action.connect('activate', self.window.on_resetsettings)
+        self.add_action(action)
+
+        action = Gio.SimpleAction.new('removepreset', None)
+        action.connect('activate', self.window.on_removepreset)
+        self.add_action(action)
+
+        action = Gio.SimpleAction.new('quit', None)
+        action.connect('activate', self.window.on_quit)
+        self.add_action(action)
 
     def do_activate(self):
         if not self.window:


### PR DESCRIPTION
This is the PR for the redesign presented in issue #4. The goal of this first iteration is to modernize the user interface without changing any of the core functionality to much.

The one breaking change is the removal of the `Apply Settings` button which now gets applied automatically after 500ms of no change to any of the equalizer scale values.
The reason to use the timer has been that the ApplySettings() function is not atomic enough to just apply changes to the control values. Calling ApplySettings for every `value-changed` signal would cause the user interface to lag.

This PR builds uppon  #9 