### PR TITLE
refactor: move file and folder paths to constants

### DIFF
--- a/pulseeq/constants.py.in
+++ b/pulseeq/constants.py.in
@@ -1,0 +1,10 @@
+import os
+
+if 'XDG_CONFIG_HOME' in os.environ:
+    CONFIG_DIR = os.path.join(os.getenv('XDG_CONFIG_HOME'), 'pulse')
+else:
+    CONFIG_DIR = os.path.join(os.getenv('HOME'), '.config', 'pulse')
+CONFIG_FILE = os.path.join(CONFIG_DIR, 'equalizerrc')
+PRESETS_FILE = os.path.join(CONFIG_DIR, 'equalizerrc.availablepresets')
+USER_PRESET_DIR = os.path.join(CONFIG_DIR, 'presets')
+SYSTEM_PRESET_DIR = os.path.join('@pkgdatadir@', 'presets')

--- a/pulseeq/equalizer.py
+++ b/pulseeq/equalizer.py
@@ -15,13 +15,7 @@ from gi.repository import Gtk, Gio, GLib
 
 import os, sys
 
-configdir = os.getenv('HOME') + '/.config/pulse'
-eqconfig = configdir + '/equalizerrc'
-eqconfig2 = configdir + '/equalizerrc.test'
-eqpresets = eqconfig + '.availablepresets'
-presetdir1 = configdir + '/presets'
-presetdir2 = '/usr/share/pulseaudio-equalizer/presets'
-
+from pulseeq.constants import *
 
 def GetSettings():
     global rawdata
@@ -44,12 +38,12 @@ def GetSettings():
 
     os.system('pulseaudio-equalizer interface.getsettings')
 
-    f = open(eqconfig, 'r')
+    f = open(CONFIG_FILE, 'r')
     rawdata = f.read().split('\n')
     f.close()
 
     rawpresets = {}
-    f = open(eqpresets, 'r')
+    f = open(PRESETS_FILE, 'r')
     rawpresets = f.read().split('\n')
     f.close()
     del rawpresets[len(rawpresets) - 1]
@@ -76,7 +70,7 @@ def GetSettings():
 
 def ApplySettings():
     print('Applying settings...')
-    f = open(eqconfig, 'w')
+    f = open(CONFIG_FILE, 'w')
     del rawdata[:]
     rawdata.append(str(ladspa_filename))
     rawdata.append(str(ladspa_name))
@@ -190,13 +184,13 @@ class Equalizer(Gtk.ApplicationWindow):
                 presetmatch = 1
 
         if presetmatch == 1:
-            if os.path.isfile(presetdir1 + '/' + preset + '.preset'):
-                f = open(presetdir1 + '/' + preset + '.preset', 'r')
+            if os.path.isfile(os.path.join(USER_PRESET_DIR, preset + '.preset')):
+                f = open(os.path.join(USER_PRESET_DIR, preset + '.preset'), 'r')
                 rawdata = f.read().split('\n')
                 f.close
                 self.lookup_action('remove').set_enabled(True)
-            elif os.path.isfile(presetdir2 + '/' + preset + '.preset'):
-                f = open(presetdir2 + '/' + preset + '.preset', 'r')
+            elif os.path.isfile(os.path.join(SYSTEM_PRESET_DIR, preset + '.preset')):
+                f = open(os.path.join(SYSTEM_PRESET_DIR, preset + '.preset'), 'r')
                 rawdata = f.read().split('\n')
                 f.close
             else:
@@ -248,7 +242,7 @@ class Equalizer(Gtk.ApplicationWindow):
         if preset == '' or presetmatch == 1:
             print('Invalid preset name')
         else:
-            f = open(presetdir1 + '/' + preset + '.preset', 'w')
+            f = open(os.path.join(USER_PRESET_DIR, preset + '.preset'), 'w')
 
             del rawdata[:]
             rawdata.append(str(ladspa_filename))
@@ -290,7 +284,7 @@ class Equalizer(Gtk.ApplicationWindow):
 
     def on_removepreset(self, action, param):
         global preset
-        os.remove(presetdir1 + '/' + preset + '.preset')
+        os.remove(os.path.join(USER_PRESET_DIR, preset + '.preset'))
 
         self.presetsbox.get_child().set_text('')
 

--- a/pulseeq/meson.build
+++ b/pulseeq/meson.build
@@ -1,4 +1,13 @@
-equalizer_sources = ['equalizer.py']
+constants_conf = configuration_data()
+constants_conf.set('pkgdatadir', join_paths(prefix, pkgdatadir))
+
+constants_file = configure_file(
+    input: 'constants.py.in',
+    output: 'constants.py',
+    configuration: constants_conf,
+)
+
+equalizer_sources = ['equalizer.py', constants_file]
 
 python.install_sources(equalizer_sources,
   subdir: modname


### PR DESCRIPTION
This commit moves file and folder constants to its own file and also
fixes not using the correct paths which where already changed in the bash
script.

This also renames presetdir1 and presetdir2 to USER_PRESET_DIR and
SYSTEM_PRESET_DIR for better clarity.

System presets now correctly uses pkgdatadir while the config folder is
now correctly set to XDG_CONFIG_HOME if available.