### PR TITLE
meson: use python version used for install in bin

### DIFF
--- a/bin/meson.build
+++ b/bin/meson.build
@@ -1,6 +1,7 @@
 bin_conf = configuration_data()
 bin_conf.set('appid', appid)
 bin_conf.set('pkgdatadir', join_paths(prefix, pkgdatadir))
+bin_conf.set('python_major_ver', python_major_ver)
 
 configure_file(
     input: 'pulseaudio-equalizer-gtk.in',

--- a/bin/pulseaudio-equalizer-gtk.in
+++ b/bin/pulseaudio-equalizer-gtk.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python@python_major_ver@
 
 import sys, os
 from gi.repository import Gio

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project('pulseaudio-equalizer-ladspa',
 
 pymod = import('python')
 python = pymod.find_installation()
+python_major_ver = python.language_version()[0]
 
 modname = 'pulseeq'
 appid = 'com.github.pulseaudio-equalizer-ladspa.Equalizer'


### PR DESCRIPTION
Use the same python version as found by pymod.find_installation() and
used for module installation in the binary start script.

fixes #18