### PR TITLE
Fix .dektop validation

### DIFF
--- a/data/com.github.pulseaudio-equalizer-ladspa.Equalizer.desktop
+++ b/data/com.github.pulseaudio-equalizer-ladspa.Equalizer.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Version=1.0
-Encoding=UTF-8
 Name=PulseAudio Equalizer
 GenericName=Equalizer
 Comment=PulseAudio LADSPA interface using MBEQ Multiband EQ plugin
@@ -8,4 +7,4 @@ Exec=pulseaudio-equalizer-gtk
 Icon=multimedia-volume-control
 StartupNotify=true
 Type=Application
-Categories=AudioVideo;Audio;Mixer;GTK; 
+Categories=AudioVideo;Audio;Mixer;GTK;


### PR DESCRIPTION
Hi, this PR fixes 2 warnings when validating the projects .desktop file:

$ desktop-file-validate ./com.github.pulseaudio-equalizer-ladspa.Equalizer.desktop
./com.github.pulseaudio-equalizer-ladspa.Equalizer.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
./com.github.pulseaudio-equalizer-ladspa.Equalizer.desktop: error: value "AudioVideo;Audio;Mixer;GTK; " for key "Categories" in group "Desktop Entry" contains an unregistered value " "; values extending the format should start with "X-"

Regards.