### PR TITLE
Python options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,46 @@ This equalizer clearly is more potent than the (deprecated ?), optional one from
 
 (this screenshot was taken with the [materia theme](https://github.com/nana-4/materia-theme) enabled, it might look different on your system)
 
-### Original Sources
+## Dependencies
+
+ * [Meson](https://mesonbuild.com/) ≥ 0.46 & [Ninja](https://ninja-build.org/)
+ * [GTK+](https://www.gtk.org/) 3
+ * [Python](https://www.python.org/) ≥ 2.7 or 3
+ * [PyGObject](https://pygobject.readthedocs.io/en/latest/) ≥ 3.30
+ * [SWH Plugins](https://github.com/swh/ladspa)
+ * [Pulseaudio](https://www.freedesktop.org/wiki/Software/PulseAudio/)
+ * [bash](https://www.gnu.org/software/bash/) & [bc](https://www.gnu.org/software/bc/)
+
+
+## Build & Install
+
+```sh
+meson build
+cd build
+ninja
+(sudo) ninja install
+```
+
+## Meson options
+
+Meson options can be set during initial configuration e.g. 
+`meson build -Doptionname=value` or within the build folder with
+`meson configure -Doptionname=value`.
+
+<dl>
+    <dt>python</dt>
+    <dd>Per default the build system will use the same python installation as
+    meson does. Set this if you want to use a specific version or binary. See
+    http://mesonbuild.com/Python-module.html#find_installation for valid names
+    or paths.</dt>
+    <dt>purelib</dt>
+    <dd>Meson defaults to install python modules to the purelib folder but some
+    distributions e.g. Debian and derivatives do not set it correctly. In that
+    case it needs to be manually set to the correct path relative to the prefix
+    e.g. -Dpurelib=lib/python3.6/dist-packages for Ubuntu 18.10</dd>
+</dl>
+
+## Original Sources
 
 Original Project: https://code.launchpad.net/~psyke83/+junk/pulseaudio-equalizer
 

--- a/bin/meson.build
+++ b/bin/meson.build
@@ -2,6 +2,7 @@ bin_conf = configuration_data()
 bin_conf.set('appid', appid)
 bin_conf.set('pkgdatadir', join_paths(prefix, pkgdatadir))
 bin_conf.set('python_major_ver', python_major_ver)
+bin_conf.set('purelib_path', join_paths(prefix, purelib_path))
 
 configure_file(
     input: 'pulseaudio-equalizer-gtk.in',

--- a/bin/pulseaudio-equalizer-gtk.in
+++ b/bin/pulseaudio-equalizer-gtk.in
@@ -7,6 +7,15 @@ resource = Gio.resource_load(
     os.path.join('@pkgdatadir@', '@appid@.gresource'))
 Gio.Resource._register(resource)
 
+try:
+    __import__('importlib').import_module('pulseeq')
+except ImportError:
+    sys.path.append('@purelib_path@')
+    try:
+        __import__('importlib').import_module('pulseeq')
+    except ImportError:
+        raise
+
 from pulseeq import equalizer
 
 app = equalizer.Application()

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('pulseaudio-equalizer-ladspa',
 )
 
 pymod = import('python')
-python = pymod.find_installation()
+python = pymod.find_installation(get_option('python'))
 python_major_ver = python.language_version()[0]
 
 modname = 'pulseeq'

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,14 @@ pythondir = python.get_path('purelib')
 pkgdatadir = join_paths(datadir, meson.project_name())
 appdir = join_paths(pythondir, modname)
 
+purelib_option = get_option('purelib')
+
+if not (purelib_option == '')
+    purelib_path = purelib_option
+else
+    purelib_path = python.get_install_dir()
+endif
+
 subdir('bin')
 subdir('data')
 subdir(modname)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('purelib',
+    type: 'string',
+    description : 'Custom python purelib path relative to prefix',
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,8 @@
+option('python',
+    type: 'string',
+    description : 'Python name or path to be used',
+)
+
 option('purelib',
     type: 'string',
     description : 'Custom python purelib path relative to prefix',

--- a/pulseeq/meson.build
+++ b/pulseeq/meson.build
@@ -7,7 +7,7 @@ constants_file = configure_file(
     configuration: constants_conf,
 )
 
-equalizer_sources = ['equalizer.py', constants_file]
+equalizer_sources = ['__init__.py', 'equalizer.py', constants_file]
 
 purelib_path = get_option('purelib')
 

--- a/pulseeq/meson.build
+++ b/pulseeq/meson.build
@@ -11,7 +11,7 @@ equalizer_sources = ['__init__.py', 'equalizer.py', constants_file]
 
 purelib_path = get_option('purelib')
 
-if not (purelib_path == '')
+if not (purelib_option == '')
     install_data(equalizer_sources,
         install_dir: join_paths(purelib_path, modname)
     )

--- a/pulseeq/meson.build
+++ b/pulseeq/meson.build
@@ -9,7 +9,14 @@ constants_file = configure_file(
 
 equalizer_sources = ['equalizer.py', constants_file]
 
-python.install_sources(equalizer_sources,
-  subdir: modname
-)
+purelib_path = get_option('purelib')
 
+if not (purelib_path == '')
+    install_data(equalizer_sources,
+        install_dir: join_paths(purelib_path, modname)
+    )
+else
+    python.install_sources(equalizer_sources,
+        subdir: modname
+    )
+endif


### PR DESCRIPTION
This PR adds both a purelib path options and a python option to the build system.

The purelib path option is needed for distribution that don't set this correctly and should fix #18 

The python option is just a pass trough of mesons python module find_installation name_or_path parameter and allows to choose which python installation should be used. See http://mesonbuild.com/Python-module.html#find_installation 

In addition an empty __init__.py is added as it is needed for python 2 to find the module.