### PR TITLE
Update pulseaudio-equalizer.in

### DIFF
--- a/bin/pulseaudio-equalizer.in
+++ b/bin/pulseaudio-equalizer.in
@@ -302,7 +302,7 @@ if [ "$1" = 'enable-config' ]; then
   echo "set-default-sink $PA_LADSPA_SINK" >>"$CONFIG_DIR"/default.pa
   #echo "set-sink-volume $PA_MASTER_SINK $PA_REAL_PREAMP" >>"$CONFIG_DIR"/default.pa
   echo "set-sink-mute $PA_MASTER_SINK 0" >>"$CONFIG_DIR"/default.pa
-  echo '.endif' >>"$CONFIG_DIR"/default.pa
+  echo '.fail' >>"$CONFIG_DIR"/default.pa
   echo '### END: Equalized audio configuration' >>"$CONFIG_DIR"/default.pa
 
   echo "Equalizer setting saved (enable-config)."


### PR DESCRIPTION
https://github.com/pulseaudio-equalizer-ladspa/equalizer/commit/8677c51854cccb10b11447c1cee6290ae7dbe68d introduced a pulseaudio error (invalid config) due to wrapping a config block in `.nofail` and `.endif`, which is invalid. Using a proper `.nofail`/`.fail` wrapper fixes this.

$ systemctl --user status pulseaudio
...
Nov 16 02:18:13 lab16 pulseaudio[1014]: E: [pulseaudio] main.c: Meta command .endif is not valid in this context