### PR TITLE
Add support for PULSE_CONFIG env var

### DIFF
--- a/bin/pulseaudio-equalizer.in
+++ b/bin/pulseaudio-equalizer.in
@@ -21,10 +21,14 @@ PA_CONTROL_MAX='30'
 PA_PREAMP='1.0'
 PA_CURRENT_PRESET=''
 
-if [ -z "$XDG_CONFIG_HOME" ]; then
-  CONFIG_DIR="$HOME"/.config/pulse
+if [ "$PULSE_CONFIG" ]; then
+  CONFIG_DIR="$(dirname "$PULSE_CONFIG")"
 else
-  CONFIG_DIR="$XDG_CONFIG_HOME"/pulse
+  if [ -z "$XDG_CONFIG_HOME" ]; then
+    CONFIG_DIR="$HOME"/.config/pulse
+  else
+    CONFIG_DIR="$XDG_CONFIG_HOME"/pulse
+  fi
 fi
 PRESET_DIR1="$CONFIG_DIR"/presets
 PRESET_DIR2="@pkgdatadir@"/presets

--- a/pulseeq/constants.py.in
+++ b/pulseeq/constants.py.in
@@ -1,9 +1,12 @@
 import os
 
-if 'XDG_CONFIG_HOME' in os.environ:
-    CONFIG_DIR = os.path.join(os.getenv('XDG_CONFIG_HOME'), 'pulse')
+if 'PULSE_CONFIG' in os.environ:
+	CONFIG_DIR = os.path.dirname(os.getenv('PULSE_CONFIG'))
 else:
-    CONFIG_DIR = os.path.join(os.getenv('HOME'), '.config', 'pulse')
+    if 'XDG_CONFIG_HOME' in os.environ:
+        CONFIG_DIR = os.path.join(os.getenv('XDG_CONFIG_HOME'), 'pulse')
+    else:
+        CONFIG_DIR = os.path.join(os.getenv('HOME'), '.config', 'pulse')
 CONFIG_FILE = os.path.join(CONFIG_DIR, 'equalizerrc')
 PRESETS_FILE = os.path.join(CONFIG_DIR, 'equalizerrc.availablepresets')
 USER_PRESET_DIR = os.path.join(CONFIG_DIR, 'presets')

--- a/pulseeq/constants.py.in
+++ b/pulseeq/constants.py.in
@@ -1,7 +1,7 @@
 import os
 
 if 'PULSE_CONFIG' in os.environ:
-	CONFIG_DIR = os.path.dirname(os.getenv('PULSE_CONFIG'))
+    CONFIG_DIR = os.path.dirname(os.getenv('PULSE_CONFIG'))
 else:
     if 'XDG_CONFIG_HOME' in os.environ:
         CONFIG_DIR = os.path.join(os.getenv('XDG_CONFIG_HOME'), 'pulse')


### PR DESCRIPTION
Official PA documentation mentions [support for several environment variables](https://www.freedesktop.org/wiki/Software/PulseAudio/FAQ/#index5h3). This PR offers support for `$PULSE_CONFIG` (the only relevant one for pulseaudio-equalizer-ladspa).