### PR TITLE
bash+python: fix support for env var

### DIFF
--- a/bin/pulseaudio-equalizer.in
+++ b/bin/pulseaudio-equalizer.in
@@ -21,8 +21,8 @@ PA_CONTROL_MAX='30'
 PA_PREAMP='1.0'
 PA_CURRENT_PRESET=''
 
-if [ "$PULSE_CONFIG" ]; then
-  CONFIG_DIR="$(dirname "$PULSE_CONFIG")"
+if [ "$PULSE_CONFIG_PATH" ]; then
+  CONFIG_DIR="$PULSE_CONFIG_PATH"
 elif [ "$XDG_CONFIG_HOME" ]; then
   CONFIG_DIR="$XDG_CONFIG_HOME"/pulse
 else

--- a/pulseeq/constants.py.in
+++ b/pulseeq/constants.py.in
@@ -1,7 +1,7 @@
 import os
 
-if 'PULSE_CONFIG' in os.environ:
-    CONFIG_DIR = os.path.dirname(os.getenv('PULSE_CONFIG'))
+if 'PULSE_CONFIG_PATH' in os.environ:
+    CONFIG_DIR = os.getenv('PULSE_CONFIG')
 elif 'XDG_CONFIG_HOME' in os.environ:
     CONFIG_DIR = os.path.join(os.getenv('XDG_CONFIG_HOME'), 'pulse')
 else:

--- a/pulseeq/constants.py.in
+++ b/pulseeq/constants.py.in
@@ -1,7 +1,7 @@
 import os
 
 if 'PULSE_CONFIG_PATH' in os.environ:
-    CONFIG_DIR = os.getenv('PULSE_CONFIG')
+    CONFIG_DIR = os.getenv('PULSE_CONFIG_PATH')
 elif 'XDG_CONFIG_HOME' in os.environ:
     CONFIG_DIR = os.path.join(os.getenv('XDG_CONFIG_HOME'), 'pulse')
 else:


### PR DESCRIPTION
Due to misleading [PulseAudio documentation](https://www.freedesktop.org/wiki/Software/PulseAudio/FAQ/#index5h3), the needed env var is in fact `PULSE_CONFIG_PATH` instead of PULSE_CONFIG (found via excellent overview [PulseAudio under the hood](https://gavv.github.io/articles/pulseaudio-under-the-hood/#configuration)). Tested and confirmed to be working as expected now.

This fixes https://github.com/pulseaudio-equalizer-ladspa/equalizer/issues/28, as with this env var support dotfiles users can handle things on their own.