### PR TITLE
bash: fix generating of equalizerrc

### DIFF
--- a/bin/pulseaudio-equalizer.in
+++ b/bin/pulseaudio-equalizer.in
@@ -74,8 +74,10 @@ if [ -f "$CONFIG_NAME" ]; then
     index=$((index+1))
     current=$((current+1))
   done
+  # trim first space
+  read  -rd '' trimmed <<< "$RAWDATA1"
   # Convert spaces into commas
-  PA_LADSPA_CONTROLS="${RAWDATA1// /,}"
+  PA_LADSPA_CONTROLS="${trimmed// /,}"
 
   # Unpack inputs from array
   index=0
@@ -85,8 +87,10 @@ if [ -f "$CONFIG_NAME" ]; then
     index=$((index+1))
     current=$((current+1))
   done
+  # trim first space
+  read  -rd '' trimmed <<< "$RAWDATA2"
   # Convert spaces into commas
-  PA_LADSPA_INPUTS="${RAWDATA2// /,}"
+  PA_LADSPA_INPUTS="${trimmed// /,}"
 fi
 
 # PyGTK Interface - Apply Settings

--- a/bin/pulseaudio-equalizer.in
+++ b/bin/pulseaudio-equalizer.in
@@ -75,7 +75,7 @@ if [ -f "$CONFIG_NAME" ]; then
     current=$((current+1))
   done
   # trim first space
-  read  -rd '' trimmed <<< "$RAWDATA1"
+  trimmed=$(echo $RAWDATA1 | sed 's/ *$//g')
   # Convert spaces into commas
   PA_LADSPA_CONTROLS="${trimmed// /,}"
 
@@ -88,7 +88,7 @@ if [ -f "$CONFIG_NAME" ]; then
     current=$((current+1))
   done
   # trim first space
-  read  -rd '' trimmed <<< "$RAWDATA2"
+  trimmed=$(echo $RAWDATA2 | sed 's/ *$//g')
   # Convert spaces into commas
   PA_LADSPA_INPUTS="${trimmed// /,}"
 fi


### PR DESCRIPTION
This PR attempts to fix generating config values in bash script.

Related issue #42

I guess that there are better way to trim leading space from variable, but this definitely works. Nevertheless I am open to suggestions to make this PR better.